### PR TITLE
Fix WebSocket private stream handling and listenKey management

### DIFF
--- a/pymexc/_async/base_websocket.py
+++ b/pymexc/_async/base_websocket.py
@@ -435,7 +435,7 @@ class _SpotWebSocket(_SpotWebSocketManager):
             if not hasattr(self, 'listenKey') or not self.listenKey:
                 # Wait a bit for _keep_alive_loop to generate the listenKey
                 import asyncio
-                for _ in range(10):  # Try for up to 5 seconds
+                for _ in range(10):  # Try for up to 5 seconds (10 * 0.5s)
                     await asyncio.sleep(0.5)
                     if hasattr(self, 'listenKey') and self.listenKey:
                         break

--- a/pymexc/_async/base_websocket.py
+++ b/pymexc/_async/base_websocket.py
@@ -212,7 +212,7 @@ class _FuturesWebSocketManager(_AsyncWebSocketManager):
 
         while not self.is_connected():
             # Wait until the connection is open before subscribing.
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
 
         await self.ws.send_json(subscription_args)
         self.subscriptions.append(subscription_args)

--- a/pymexc/_async/futures.py
+++ b/pymexc/_async/futures.py
@@ -41,10 +41,12 @@ logger = logging.getLogger(__name__)
 
 try:
     from .base import _FuturesHTTP
-    from ..base_websocket import FUTURES_PERSONAL_TOPICS, _FuturesWebSocket
+    from .base_websocket import _FuturesWebSocket
+    from ..base_websocket import FUTURES_PERSONAL_TOPICS
 except ImportError:
     from pymexc._async.base import _FuturesHTTP
-    from pymexc.base_websocket import FUTURES_PERSONAL_TOPICS, _FuturesWebSocket
+    from pymexc._async.base_websocket import _FuturesWebSocket
+    from pymexc.base_websocket import FUTURES_PERSONAL_TOPICS
 
 
 class HTTP(_FuturesHTTP):

--- a/pymexc/base_websocket.py
+++ b/pymexc/base_websocket.py
@@ -432,7 +432,7 @@ class _WebSocketManager:
                     if "o" in message or "orderId" in message or "orderStatus" in message:
                         topic = "private.orders"
                     # Check for deal/trade fields  
-                    elif "t" in message or "tradeId" in message or "price" in message and "quantity" in message:
+                    elif "t" in message or "tradeId" in message or ("price" in message and "quantity" in message):
                         topic = "private.deals"
                     # Default to account updates
                     else:

--- a/pymexc/base_websocket.py
+++ b/pymexc/base_websocket.py
@@ -390,6 +390,11 @@ class _WebSocketManager:
             "public.increase.depth": "publicIncreaseDepths",
             "public.limit.depth": "publicLimitDepths",
             "public.bookTicker": "publicBookTicker",
+            # Aggregated public topics
+            "public.aggre.deals": "publicAggreDeals",
+            "public.aggre.depth": "publicAggreDepths",
+            "public.aggre.bookTicker": "publicAggreBookTicker",
+            "public.bookTicker.batch": "publicBookTickerBatch",
             "private.account": "privateAccount",
             "private.deals": "privateDeals",
             "private.orders": "privateOrders",

--- a/pymexc/spot.py
+++ b/pymexc/spot.py
@@ -2039,7 +2039,7 @@ class WebSocket(_SpotWebSocket):
         self,
         callback: Callable[[dict | ProtoTyping.PublicDealsV3Api], None],
         symbol: Union[str, List[str]],
-        interval: str = None
+        speed: str = "100ms",
     ):
         """
         ### Trade Streams
@@ -2051,7 +2051,7 @@ class WebSocket(_SpotWebSocket):
         :type callback: Callable[[dict | ProtoTyping.PublicDealsV3Api], None]
         :param symbol: the name of the contract
         :type symbol: Union[str,List[str]]
-        :param interval: the interval for the stream, default is None. Possible values '100ms' or '10s'
+        :param speed: aggregated stream speed. Possible values '100ms' or '10ms'
         :type symbol: str
 
         :return: None
@@ -2062,7 +2062,7 @@ class WebSocket(_SpotWebSocket):
             symbols = symbol  # list
         params = [dict(symbol=s) for s in symbols]
         topic = "public.aggre.deals"
-        self._ws_subscribe(topic, callback, params, interval)
+        self._ws_subscribe(topic, callback, params, speed)
 
     def kline_stream(
         self,
@@ -2104,6 +2104,7 @@ class WebSocket(_SpotWebSocket):
         self,
         callback: Callable[[dict | ProtoTyping.PublicIncreaseDepthsV3Api], None],
         symbol: str,
+        speed: str = "100ms",
     ):
         """
         ### Diff.Depth Stream
@@ -2120,7 +2121,7 @@ class WebSocket(_SpotWebSocket):
         """
         params = [dict(symbol=symbol)]
         topic = "public.aggre.depth"
-        self._ws_subscribe(topic, callback, params)
+        self._ws_subscribe(topic, callback, params, speed)
 
     def limit_depth_stream(
         self,
@@ -2151,6 +2152,7 @@ class WebSocket(_SpotWebSocket):
         self,
         callback: Callable[[dict | ProtoTyping.PublicBookTickerV3Api], None],
         symbol: str,
+        speed: str = "100ms",
     ):
         """
         ### Individual Symbol Book Ticker Streams
@@ -2167,7 +2169,7 @@ class WebSocket(_SpotWebSocket):
         """
         params = [dict(symbol=symbol)]
         topic = "public.aggre.bookTicker"
-        self._ws_subscribe(topic, callback, params)
+        self._ws_subscribe(topic, callback, params, speed)
 
     def book_ticker_batch_stream(
         self,


### PR DESCRIPTION
## Summary
- Fixed private WebSocket streams failing to initialize properly by ensuring listenKey availability  
- Improved message routing for private streams without channel fields
- Enhanced error handling and reconnection logic for authenticated streams

## Changes
- Added `_ensure_listen_key()` method to guarantee listenKey is available before private subscriptions
- Implemented fallback topic detection for private messages that lack channel field
- Fixed import statements in futures module for better module resolution
- Added robust error handling when listenKey generation fails

## Test Plan
- [ ] Verify private.account updates stream connects successfully
- [ ] Verify private.deals stream receives trade updates
- [ ] Verify private.orders stream receives order updates
- [ ] Test reconnection behavior after connection loss
- [ ] Confirm no regression in public WebSocket streams

## Impact
This fix resolves critical issues with private WebSocket streams that were causing authentication failures and missed updates in production environments.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-27 02:05:15 UTC

<h3>Summary</h3>

This PR addresses critical issues with private WebSocket streams in the MEXC Python client by implementing robust listenKey management and improving message routing.

**Key improvements:**
- **listenKey Management**: Added `_ensure_listen_key()` method that proactively generates authentication keys for private streams with proper error handling
- **Message Routing**: Enhanced fallback logic to route private messages without channel fields by analyzing message content patterns
- **Async Fixes**: Corrected `time.sleep(0.1)` to `await asyncio.sleep(0.1)` in futures WebSocket manager  
- **Import Resolution**: Fixed module imports in futures.py to properly resolve async WebSocket classes
- **API Consistency**: Standardized parameter names (`speed` instead of `interval`) and added speed control to aggregated stream methods

**Issues identified:**
- Logic error in message content detection that could cause incorrect operator precedence
- Missing return statement in topic validation that could lead to downstream issues
- Minor documentation inconsistency in timeout calculation

The changes directly address authentication failures that were preventing private WebSocket streams from functioning correctly in production environments.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor issues that should be addressed
- Score reflects mostly solid implementation with a few logic issues: the operator precedence bug could cause incorrect message routing, and missing return statement needs fixing. The core functionality improvements are well-implemented.
- Pay attention to `pymexc/base_websocket.py` for the logic fixes in message routing and topic validation

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| pymexc/_async/base_websocket.py | 4/5 | Fixed async/await issue in futures websocket and added listenKey validation for private streams with proper error handling |
| pymexc/_async/spot.py | 4/5 | Added _ensure_listen_key method and integrated it into private stream methods, improved parameter naming and interval handling |
| pymexc/base_websocket.py | 3/5 | Enhanced message routing for private streams without channel fields and improved ping timer cleanup, but logic could be more robust |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant SpotWebSocket
    participant HTTP_Client
    participant MEXC_WebSocket
    participant MessageRouter

    Client->>SpotWebSocket: subscribe to private stream
    SpotWebSocket->>SpotWebSocket: _ensure_listen_key()
    
    alt listenKey not available
        SpotWebSocket->>HTTP_Client: create_listen_key()
        HTTP_Client->>MEXC_WebSocket: POST /api/v3/userDataStream
        MEXC_WebSocket-->>HTTP_Client: {listenKey: "xyz123"}
        HTTP_Client-->>SpotWebSocket: auth response
        SpotWebSocket->>SpotWebSocket: update endpoint with listenKey
    end
    
    SpotWebSocket->>MEXC_WebSocket: connect with listenKey
    SpotWebSocket->>MEXC_WebSocket: subscribe to private topic
    MEXC_WebSocket-->>SpotWebSocket: subscription confirmed
    
    loop Message Processing
        MEXC_WebSocket-->>MessageRouter: incoming message
        
        alt message has channel field
            MessageRouter->>MessageRouter: extract topic from channel
        else no channel field (private message)
            MessageRouter->>MessageRouter: analyze message content
            MessageRouter->>MessageRouter: route to private.orders/deals/account
        end
        
        MessageRouter->>Client: callback(message_data)
    end
```

<!-- /greptile_comment -->