### PR TITLE
Add miniTicker and miniTickers WebSocket stream wrappers

### DIFF
--- a/pymexc/_async/spot.py
+++ b/pymexc/_async/spot.py
@@ -37,15 +37,49 @@ import logging
 from asyncio import AbstractEventLoop
 from typing import Callable, List, Literal, Optional, Union
 import warnings
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
 try:
     from .base import _SpotHTTP, SPOT as SPOT_HTTP
     from .base_websocket import _SpotWebSocket, SPOT as SPOT_WS
+    from ..proto import ProtoTyping
 except ImportError:
     from pymexc._async.base import _SpotHTTP, SPOT as SPOT_HTTP
     from pymexc._async.base_websocket import _SpotWebSocket, SPOT as SPOT_WS
+    from pymexc.proto import ProtoTyping
+
+
+class Timezone(str, Enum):
+    """Valid timezone values for miniTicker and miniTickers streams"""
+    H24 = "24H"
+    UTC_M10 = "UTC-10"
+    UTC_M8 = "UTC-8"
+    UTC_M7 = "UTC-7"
+    UTC_M6 = "UTC-6"
+    UTC_M5 = "UTC-5"
+    UTC_M4 = "UTC-4"
+    UTC_M3 = "UTC-3"
+    UTC_0 = "UTC+0"
+    UTC_1 = "UTC+1"
+    UTC_2 = "UTC+2"
+    UTC_3 = "UTC+3"
+    UTC_4 = "UTC+4"
+    UTC_4_30 = "UTC+4:30"
+    UTC_5 = "UTC+5"
+    UTC_5_30 = "UTC+5:30"
+    UTC_6 = "UTC+6"
+    UTC_7 = "UTC+7"
+    UTC_8 = "UTC+8"
+    UTC_9 = "UTC+9"
+    UTC_10 = "UTC+10"
+    UTC_11 = "UTC+11"
+    UTC_12 = "UTC+12"
+    UTC_12_45 = "UTC+12:45"
+    UTC_13 = "UTC+13"
+
+VALID_TIMEZONES = {tz.value for tz in Timezone}
 
 
 class HTTP(_SpotHTTP):
@@ -2189,7 +2223,7 @@ class WebSocket(_SpotWebSocket):
 
     async def mini_ticker_stream(
         self,
-        callback: Callable[..., None],
+        callback: Callable[[dict | ProtoTyping.PublicMiniTickerV3Api], None],
         symbol: str,
         timezone: str = "UTC+8",
     ):
@@ -2200,7 +2234,7 @@ class WebSocket(_SpotWebSocket):
         https://mexcdevelop.github.io/apidocs/spot_v3_en/#miniticker
 
         :param callback: the callback function
-        :type callback: Callable[..., None]
+        :type callback: Callable[[dict | ProtoTyping.PublicMiniTickerV3Api], None]
         :param symbol: the name of the trading pair
         :type symbol: str
         :param timezone: timezone for the ticker data. Valid values: 24H, UTC-10, UTC-8, UTC-7, UTC-6, UTC-5, UTC-4, UTC-3, UTC+0, UTC+1, UTC+2, UTC+3, UTC+4, UTC+4:30, UTC+5, UTC+5:30, UTC+6, UTC+7, UTC+8 (default), UTC+9, UTC+10, UTC+11, UTC+12, UTC+12:45, UTC+13
@@ -2208,13 +2242,15 @@ class WebSocket(_SpotWebSocket):
 
         :return: None
         """
+        if timezone not in VALID_TIMEZONES:
+            raise ValueError(f"Invalid timezone: {timezone}. Must be one of {sorted(VALID_TIMEZONES)}")
         params = [dict(symbol=symbol, timezone=timezone)]
         topic = "public.miniTicker"
         await self._ws_subscribe(topic, callback, params)
 
     async def mini_tickers_stream(
         self,
-        callback: Callable[..., None],
+        callback: Callable[[dict | ProtoTyping.PublicMiniTickersV3Api], None],
         timezone: str = "UTC+8",
     ):
         """
@@ -2224,12 +2260,14 @@ class WebSocket(_SpotWebSocket):
         https://mexcdevelop.github.io/apidocs/spot_v3_en/#minitickers
 
         :param callback: the callback function
-        :type callback: Callable[..., None]
+        :type callback: Callable[[dict | ProtoTyping.PublicMiniTickersV3Api], None]
         :param timezone: timezone for the ticker data. Valid values: 24H, UTC-10, UTC-8, UTC-7, UTC-6, UTC-5, UTC-4, UTC-3, UTC+0, UTC+1, UTC+2, UTC+3, UTC+4, UTC+4:30, UTC+5, UTC+5:30, UTC+6, UTC+7, UTC+8 (default), UTC+9, UTC+10, UTC+11, UTC+12, UTC+12:45, UTC+13
         :type timezone: str
 
         :return: None
         """
+        if timezone not in VALID_TIMEZONES:
+            raise ValueError(f"Invalid timezone: {timezone}. Must be one of {sorted(VALID_TIMEZONES)}")
         params = [dict(timezone=timezone)]
         topic = "public.miniTickers"
         await self._ws_subscribe(topic, callback, params)

--- a/pymexc/_async/spot.py
+++ b/pymexc/_async/spot.py
@@ -2187,6 +2187,53 @@ class WebSocket(_SpotWebSocket):
         topic = "public.bookTicker.batch"
         await self._ws_subscribe(topic, callback, params)
 
+    async def mini_ticker_stream(
+        self,
+        callback: Callable[..., None],
+        symbol: str,
+        timezone: str = "UTC+8",
+    ):
+        """
+        ### MiniTicker Stream
+        MiniTicker of the specified trading pair in the specified timezone, pushed every 3 seconds.
+
+        https://mexcdevelop.github.io/apidocs/spot_v3_en/#miniticker
+
+        :param callback: the callback function
+        :type callback: Callable[..., None]
+        :param symbol: the name of the trading pair
+        :type symbol: str
+        :param timezone: timezone for the ticker data. Valid values: 24H, UTC-10, UTC-8, UTC-7, UTC-6, UTC-5, UTC-4, UTC-3, UTC+0, UTC+1, UTC+2, UTC+3, UTC+4, UTC+4:30, UTC+5, UTC+5:30, UTC+6, UTC+7, UTC+8 (default), UTC+9, UTC+10, UTC+11, UTC+12, UTC+12:45, UTC+13
+        :type timezone: str
+
+        :return: None
+        """
+        params = [dict(symbol=symbol, timezone=timezone)]
+        topic = "public.miniTicker"
+        await self._ws_subscribe(topic, callback, params)
+
+    async def mini_tickers_stream(
+        self,
+        callback: Callable[..., None],
+        timezone: str = "UTC+8",
+    ):
+        """
+        ### MiniTickers Stream
+        MiniTickers of all trading pairs in the specified timezone, pushed every 3 seconds.
+
+        https://mexcdevelop.github.io/apidocs/spot_v3_en/#minitickers
+
+        :param callback: the callback function
+        :type callback: Callable[..., None]
+        :param timezone: timezone for the ticker data. Valid values: 24H, UTC-10, UTC-8, UTC-7, UTC-6, UTC-5, UTC-4, UTC-3, UTC+0, UTC+1, UTC+2, UTC+3, UTC+4, UTC+4:30, UTC+5, UTC+5:30, UTC+6, UTC+7, UTC+8 (default), UTC+9, UTC+10, UTC+11, UTC+12, UTC+12:45, UTC+13
+        :type timezone: str
+
+        :return: None
+        """
+        params = [dict(timezone=timezone)]
+        topic = "public.miniTickers"
+        await self._ws_subscribe(topic, callback, params)
+
     # <=================================================================>
     #
     #                                Private

--- a/pymexc/spot.py
+++ b/pymexc/spot.py
@@ -35,10 +35,10 @@ while True:
 import logging
 import threading
 import time
-from tkinter import N
 from typing import Callable, List, Literal, Optional, Union
 import warnings
 import json
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,37 @@ except ImportError:
     from .proto import ProtoTyping
 
 __all__ = ["HTTP", "WebSocket", "AsyncHTTP", "AsyncWebSocket"]
+
+
+class Timezone(str, Enum):
+    """Valid timezone values for miniTicker and miniTickers streams"""
+    H24 = "24H"
+    UTC_M10 = "UTC-10"
+    UTC_M8 = "UTC-8"
+    UTC_M7 = "UTC-7"
+    UTC_M6 = "UTC-6"
+    UTC_M5 = "UTC-5"
+    UTC_M4 = "UTC-4"
+    UTC_M3 = "UTC-3"
+    UTC_0 = "UTC+0"
+    UTC_1 = "UTC+1"
+    UTC_2 = "UTC+2"
+    UTC_3 = "UTC+3"
+    UTC_4 = "UTC+4"
+    UTC_4_30 = "UTC+4:30"
+    UTC_5 = "UTC+5"
+    UTC_5_30 = "UTC+5:30"
+    UTC_6 = "UTC+6"
+    UTC_7 = "UTC+7"
+    UTC_8 = "UTC+8"
+    UTC_9 = "UTC+9"
+    UTC_10 = "UTC+10"
+    UTC_11 = "UTC+11"
+    UTC_12 = "UTC+12"
+    UTC_12_45 = "UTC+12:45"
+    UTC_13 = "UTC+13"
+
+VALID_TIMEZONES = {tz.value for tz in Timezone}
 
 
 class HTTP(_SpotHTTP):
@@ -2214,6 +2245,8 @@ class WebSocket(_SpotWebSocket):
 
         :return: None
         """
+        if timezone not in VALID_TIMEZONES:
+            raise ValueError(f"Invalid timezone: {timezone}. Must be one of {sorted(VALID_TIMEZONES)}")
         params = [dict(symbol=symbol, timezone=timezone)]
         topic = "public.miniTicker"
         self._ws_subscribe(topic, callback, params)
@@ -2236,6 +2269,8 @@ class WebSocket(_SpotWebSocket):
 
         :return: None
         """
+        if timezone not in VALID_TIMEZONES:
+            raise ValueError(f"Invalid timezone: {timezone}. Must be one of {sorted(VALID_TIMEZONES)}")
         params = [dict(timezone=timezone)]
         topic = "public.miniTickers"
         self._ws_subscribe(topic, callback, params)

--- a/pymexc/spot.py
+++ b/pymexc/spot.py
@@ -2193,6 +2193,53 @@ class WebSocket(_SpotWebSocket):
         topic = "public.bookTicker.batch"
         self._ws_subscribe(topic, callback, params)
 
+    def mini_ticker_stream(
+        self,
+        callback: Callable[[dict | ProtoTyping.PublicMiniTickerV3Api], None],
+        symbol: str,
+        timezone: str = "UTC+8",
+    ):
+        """
+        ### MiniTicker Stream
+        MiniTicker of the specified trading pair in the specified timezone, pushed every 3 seconds.
+
+        https://mexcdevelop.github.io/apidocs/spot_v3_en/#miniticker
+
+        :param callback: the callback function
+        :type callback: Callable[[dict | ProtoTyping.PublicMiniTickerV3Api], None]
+        :param symbol: the name of the trading pair
+        :type symbol: str
+        :param timezone: timezone for the ticker data. Valid values: 24H, UTC-10, UTC-8, UTC-7, UTC-6, UTC-5, UTC-4, UTC-3, UTC+0, UTC+1, UTC+2, UTC+3, UTC+4, UTC+4:30, UTC+5, UTC+5:30, UTC+6, UTC+7, UTC+8 (default), UTC+9, UTC+10, UTC+11, UTC+12, UTC+12:45, UTC+13
+        :type timezone: str
+
+        :return: None
+        """
+        params = [dict(symbol=symbol, timezone=timezone)]
+        topic = "public.miniTicker"
+        self._ws_subscribe(topic, callback, params)
+
+    def mini_tickers_stream(
+        self,
+        callback: Callable[[dict | ProtoTyping.PublicMiniTickersV3Api], None],
+        timezone: str = "UTC+8",
+    ):
+        """
+        ### MiniTickers Stream
+        MiniTickers of all trading pairs in the specified timezone, pushed every 3 seconds.
+
+        https://mexcdevelop.github.io/apidocs/spot_v3_en/#minitickers
+
+        :param callback: the callback function
+        :type callback: Callable[[dict | ProtoTyping.PublicMiniTickersV3Api], None]
+        :param timezone: timezone for the ticker data. Valid values: 24H, UTC-10, UTC-8, UTC-7, UTC-6, UTC-5, UTC-4, UTC-3, UTC+0, UTC+1, UTC+2, UTC+3, UTC+4, UTC+4:30, UTC+5, UTC+5:30, UTC+6, UTC+7, UTC+8 (default), UTC+9, UTC+10, UTC+11, UTC+12, UTC+12:45, UTC+13
+        :type timezone: str
+
+        :return: None
+        """
+        params = [dict(timezone=timezone)]
+        topic = "public.miniTickers"
+        self._ws_subscribe(topic, callback, params)
+
     # <=================================================================>
     #
     #                                Private

--- a/tests/test_miniticker_streams.py
+++ b/tests/test_miniticker_streams.py
@@ -1,0 +1,241 @@
+"""
+Tests for miniTicker and miniTickers WebSocket streams.
+Tests timezone validation, sync/async implementations, and proper type annotations.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+import sys
+import os
+
+# Add parent directory to path to import pymexc
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pymexc.spot import WebSocket as SyncWebSocket, Timezone, VALID_TIMEZONES
+from pymexc._async.spot import WebSocket as AsyncWebSocket
+from pymexc.proto import ProtoTyping
+
+
+class TestSyncMiniTickerStreams:
+    """Test suite for sync miniTicker WebSocket streams."""
+
+    def test_timezone_enum_exists(self):
+        """Test that Timezone enum is properly defined."""
+        assert hasattr(Timezone, 'H24')
+        assert hasattr(Timezone, 'UTC_8')
+        assert Timezone.H24.value == "24H"
+        assert Timezone.UTC_8.value == "UTC+8"
+
+    def test_valid_timezones_set(self):
+        """Test that VALID_TIMEZONES contains all expected values."""
+        expected_timezones = {
+            "24H", "UTC-10", "UTC-8", "UTC-7", "UTC-6", "UTC-5", "UTC-4", "UTC-3",
+            "UTC+0", "UTC+1", "UTC+2", "UTC+3", "UTC+4", "UTC+4:30", "UTC+5",
+            "UTC+5:30", "UTC+6", "UTC+7", "UTC+8", "UTC+9", "UTC+10", "UTC+11",
+            "UTC+12", "UTC+12:45", "UTC+13"
+        }
+        assert VALID_TIMEZONES == expected_timezones
+
+    @patch('pymexc.spot.HTTP')
+    def test_mini_ticker_stream_with_valid_timezone(self, mock_http):
+        """Test mini_ticker_stream accepts valid timezone."""
+        mock_http.return_value.create_listen_key.return_value = {'listenKey': 'test_key'}
+
+        ws = SyncWebSocket(api_key='test', api_secret='test')
+        ws._ws_subscribe = MagicMock()
+
+        callback = MagicMock()
+        ws.mini_ticker_stream(callback, "BTCUSDT", timezone="UTC+9")
+
+        # Verify _ws_subscribe was called with correct parameters
+        ws._ws_subscribe.assert_called_once_with(
+            "public.miniTicker",
+            callback,
+            [{"symbol": "BTCUSDT", "timezone": "UTC+9"}]
+        )
+
+    @patch('pymexc.spot.HTTP')
+    def test_mini_ticker_stream_with_invalid_timezone(self, mock_http):
+        """Test mini_ticker_stream rejects invalid timezone."""
+        mock_http.return_value.create_listen_key.return_value = {'listenKey': 'test_key'}
+
+        ws = SyncWebSocket(api_key='test', api_secret='test')
+        callback = MagicMock()
+
+        with pytest.raises(ValueError) as exc_info:
+            ws.mini_ticker_stream(callback, "BTCUSDT", timezone="INVALID")
+
+        assert "Invalid timezone" in str(exc_info.value)
+        assert "INVALID" in str(exc_info.value)
+
+    @patch('pymexc.spot.HTTP')
+    def test_mini_ticker_stream_default_timezone(self, mock_http):
+        """Test mini_ticker_stream uses default timezone UTC+8."""
+        mock_http.return_value.create_listen_key.return_value = {'listenKey': 'test_key'}
+
+        ws = SyncWebSocket(api_key='test', api_secret='test')
+        ws._ws_subscribe = MagicMock()
+
+        callback = MagicMock()
+        ws.mini_ticker_stream(callback, "BTCUSDT")
+
+        # Verify default timezone is UTC+8
+        ws._ws_subscribe.assert_called_once_with(
+            "public.miniTicker",
+            callback,
+            [{"symbol": "BTCUSDT", "timezone": "UTC+8"}]
+        )
+
+    @patch('pymexc.spot.HTTP')
+    def test_mini_tickers_stream_with_valid_timezone(self, mock_http):
+        """Test mini_tickers_stream accepts valid timezone."""
+        mock_http.return_value.create_listen_key.return_value = {'listenKey': 'test_key'}
+
+        ws = SyncWebSocket(api_key='test', api_secret='test')
+        ws._ws_subscribe = MagicMock()
+
+        callback = MagicMock()
+        ws.mini_tickers_stream(callback, timezone="24H")
+
+        # Verify _ws_subscribe was called with correct parameters
+        ws._ws_subscribe.assert_called_once_with(
+            "public.miniTickers",
+            callback,
+            [{"timezone": "24H"}]
+        )
+
+    @patch('pymexc.spot.HTTP')
+    def test_mini_tickers_stream_with_invalid_timezone(self, mock_http):
+        """Test mini_tickers_stream rejects invalid timezone."""
+        mock_http.return_value.create_listen_key.return_value = {'listenKey': 'test_key'}
+
+        ws = SyncWebSocket(api_key='test', api_secret='test')
+        callback = MagicMock()
+
+        with pytest.raises(ValueError) as exc_info:
+            ws.mini_tickers_stream(callback, timezone="UTC+99")
+
+        assert "Invalid timezone" in str(exc_info.value)
+
+    @patch('pymexc.spot.HTTP')
+    def test_all_valid_timezones(self, mock_http):
+        """Test that all timezone enum values are accepted."""
+        mock_http.return_value.create_listen_key.return_value = {'listenKey': 'test_key'}
+
+        ws = SyncWebSocket(api_key='test', api_secret='test')
+        ws._ws_subscribe = MagicMock()
+        callback = MagicMock()
+
+        # Test each timezone value
+        for tz in Timezone:
+            ws._ws_subscribe.reset_mock()
+            ws.mini_ticker_stream(callback, "BTCUSDT", timezone=tz.value)
+            assert ws._ws_subscribe.called
+
+
+class TestAsyncMiniTickerStreams:
+    """Test suite for async miniTicker WebSocket streams."""
+
+    @pytest.mark.asyncio
+    async def test_async_timezone_enum_exists(self):
+        """Test that async module has Timezone enum."""
+        from pymexc._async.spot import Timezone as AsyncTimezone, VALID_TIMEZONES as AsyncValidTimezones
+
+        assert hasattr(AsyncTimezone, 'H24')
+        assert hasattr(AsyncTimezone, 'UTC_8')
+        assert AsyncValidTimezones == VALID_TIMEZONES
+
+    @pytest.mark.asyncio
+    @patch('pymexc._async.spot.HTTP')
+    async def test_async_mini_ticker_stream_with_valid_timezone(self, mock_http):
+        """Test async mini_ticker_stream accepts valid timezone."""
+        from unittest.mock import AsyncMock
+        mock_http.return_value.create_listen_key = AsyncMock(return_value={'listenKey': 'test_key'})
+
+        ws = AsyncWebSocket(api_key='test', api_secret='test')
+        ws._ws_subscribe = AsyncMock()
+
+        callback = MagicMock()
+        await ws.mini_ticker_stream(callback, "ETHUSDT", timezone="UTC+0")
+
+        # Verify _ws_subscribe was called with correct parameters
+        ws._ws_subscribe.assert_called_once_with(
+            "public.miniTicker",
+            callback,
+            [{"symbol": "ETHUSDT", "timezone": "UTC+0"}]
+        )
+
+    @pytest.mark.asyncio
+    @patch('pymexc._async.spot.HTTP')
+    async def test_async_mini_ticker_stream_with_invalid_timezone(self, mock_http):
+        """Test async mini_ticker_stream rejects invalid timezone."""
+        from unittest.mock import AsyncMock
+        mock_http.return_value.create_listen_key = AsyncMock(return_value={'listenKey': 'test_key'})
+
+        ws = AsyncWebSocket(api_key='test', api_secret='test')
+        callback = MagicMock()
+
+        with pytest.raises(ValueError) as exc_info:
+            await ws.mini_ticker_stream(callback, "ETHUSDT", timezone="WRONG")
+
+        assert "Invalid timezone" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch('pymexc._async.spot.HTTP')
+    async def test_async_mini_tickers_stream_default_timezone(self, mock_http):
+        """Test async mini_tickers_stream uses default timezone UTC+8."""
+        from unittest.mock import AsyncMock
+        mock_http.return_value.create_listen_key = AsyncMock(return_value={'listenKey': 'test_key'})
+
+        ws = AsyncWebSocket(api_key='test', api_secret='test')
+        ws._ws_subscribe = AsyncMock()
+
+        callback = MagicMock()
+        await ws.mini_tickers_stream(callback)
+
+        # Verify default timezone is UTC+8
+        ws._ws_subscribe.assert_called_once_with(
+            "public.miniTickers",
+            callback,
+            [{"timezone": "UTC+8"}]
+        )
+
+
+class TestTypeAnnotations:
+    """Test that type annotations are correct."""
+
+    def test_sync_mini_ticker_callback_type(self):
+        """Test that sync mini_ticker_stream has correct callback type hint."""
+        import inspect
+        from typing import get_type_hints
+
+        # Get the method signature
+        sig = inspect.signature(SyncWebSocket.mini_ticker_stream)
+
+        # Verify callback parameter exists
+        assert 'callback' in sig.parameters
+        assert 'symbol' in sig.parameters
+        assert 'timezone' in sig.parameters
+
+        # Verify timezone has default value
+        assert sig.parameters['timezone'].default == "UTC+8"
+
+    def test_async_mini_ticker_callback_type(self):
+        """Test that async mini_ticker_stream has correct callback type hint."""
+        import inspect
+
+        # Get the method signature
+        sig = inspect.signature(AsyncWebSocket.mini_ticker_stream)
+
+        # Verify callback parameter exists
+        assert 'callback' in sig.parameters
+        assert 'symbol' in sig.parameters
+        assert 'timezone' in sig.parameters
+
+        # Verify timezone has default value
+        assert sig.parameters['timezone'].default == "UTC+8"
+
+
+if __name__ == "__main__":
+    # Run tests
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary
- Add `mini_ticker_stream()` method for single symbol ticker updates
- Add `mini_tickers_stream()` method for all symbols ticker updates
- Both methods support timezone parameter (default: UTC+8)
- Implemented in both sync and async WebSocket classes

## Implementation Details
- Follows existing WebSocket stream patterns
- Proto types already exist (PublicMiniTickerV3Api, PublicMiniTickersV3Api)
- Updates pushed every 3 seconds from MEXC API
- Supports 24H and various UTC timezone offsets

## Files Changed
- `pymexc/spot.py` - Sync WebSocket implementation
- `pymexc/_async/spot.py` - Async WebSocket implementation

## Testing
- Methods follow the same pattern as existing streams (low risk)
- Can be tested with existing WebSocket infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-03 12:58:38 UTC

<h3>Summary</h3>
This PR adds WebSocket streaming functionality for MEXC's miniTicker data feeds by introducing two new methods to both synchronous and asynchronous spot WebSocket classes. The `mini_ticker_stream()` method provides real-time ticker updates for a single trading pair, while `mini_tickers_stream()` delivers ticker data for all trading pairs simultaneously. Both methods accept a timezone parameter (defaulting to UTC+8) to accommodate different regional time preferences.

The implementation seamlessly integrates with the existing pymexc architecture by following established WebSocket stream patterns. It leverages the `_ws_subscribe` infrastructure that's already used by other stream methods and utilizes proto types (`PublicMiniTickerV3Api` and `PublicMiniTickersV3Api`) that were already present in the codebase. This suggests the functionality was planned but just needed the wrapper methods to expose it to users.

The miniTicker streams serve as lightweight alternatives to full ticker streams, providing essential price and volume data with updates every 3 seconds. This makes them ideal for applications that need real-time market data without the overhead of more comprehensive ticker information. The consistent implementation across both sync (`pymexc/spot.py`) and async (`pymexc/_async/spot.py`) modules ensures feature parity and maintains the library's dual-mode architecture.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `pymexc/spot.py` | 5/5 | Added `mini_ticker_stream()` and `mini_tickers_stream()` methods for synchronous WebSocket miniTicker data streaming |
| `pymexc/_async/spot.py` | 5/5 | Added `mini_ticker_stream()` and `mini_tickers_stream()` methods for asynchronous WebSocket miniTicker data streaming |

</details>
<h3>Confidence score: 5/5</h3>

- This PR is safe to merge with minimal risk as it adds new functionality without modifying existing code paths
- Score reflects simple, well-documented methods that follow established patterns and use existing infrastructure
- No files require special attention as both implementations are straightforward and consistent with codebase conventions

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant WebSocket as "WebSocket Client"
    participant API as "MEXC WebSocket API"
    participant Auth as "HTTP API"

    User->>WebSocket: "mini_ticker_stream(callback, symbol, timezone)"
    WebSocket->>WebSocket: "Prepare parameters: {symbol, timezone}"
    WebSocket->>API: "Subscribe to 'public.miniTicker' topic"
    API-->>WebSocket: "Subscription confirmed"
    
    loop Every 3 seconds
        API->>WebSocket: "MiniTicker data for symbol"
        WebSocket->>User: "callback(ticker_data)"
    end

    User->>WebSocket: "mini_tickers_stream(callback, timezone)"
    WebSocket->>WebSocket: "Prepare parameters: {timezone}"
    WebSocket->>API: "Subscribe to 'public.miniTickers' topic"
    API-->>WebSocket: "Subscription confirmed"
    
    loop Every 3 seconds
        API->>WebSocket: "MiniTickers data for all symbols"
        WebSocket->>User: "callback(tickers_data)"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->