### PR TITLE
Bug--ping-mechanism-mismatch-with-mexc's-handshake-protocol

### DIFF
--- a/pymexc/futures.py
+++ b/pymexc/futures.py
@@ -1445,7 +1445,7 @@ class WebSocket(_FuturesWebSocket):
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
         personal_callback: Optional[Callable[..., None]] = None,
-        ping_interval: Optional[int] = 20,
+        ping_interval: Optional[int] = 55,
         ping_timeout: Optional[int] = 10,
         retries: Optional[int] = 10,
         restart_on_error: Optional[bool] = True,


### PR DESCRIPTION
- Enhanced the handling of pong frames to clarify that application-level pings are sent on a timer, not in response to pong frames.
- Improved error handling for ping timer cancellation to prevent potential issues during WebSocket connection closures.

The ping mechanism had a fundamental design flaw - it sent a ping only once after connection, then waited for websocket library's OPCODE_PONG responses to trigger subsequent pings. This doesn't match
   MEXC's requirement to send continuous application-level pings every 59 seconds.