### PR TITLE
Fix futures trading endpoints: JSON-body POST signing, api.mexc.com base URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,5 @@ upload.bat
 .claude/
 .serena/
 
-docs/tmp/
+docs/
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,4 @@ upload.bat
 .claude/
 .serena/
 
-docs/
+docs/tmp/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Base of code was taken from [pybit](https://github.com/bybit-exchange/pybit) lib
 
 MEXC Futures API for create orders is on maintance now. **_But you can bypass it_**. See [this issue](https://github.com/makarworld/pymexc/issues/15) for more information.
 
+## Fork note: futures REST trading fixed
+
+This fork restores futures REST trading. POST requests now sign `accessKey + timestamp + compact-JSON-body`, where the signed body is byte-identical to the body actually sent. The futures base URL is `https://api.mexc.com`. Trading endpoints (order placement / cancellation) were live-verified on 2026-06-10. The maintenance-era bypass note above is therefore obsolete for order placement.
+
 # Installation
 
 You can install pymexc using pip:

--- a/pymexc/_async/base.py
+++ b/pymexc/_async/base.py
@@ -8,10 +8,15 @@ from urllib.parse import urlencode
 
 from curl_cffi import requests
 
+try:
+    from ..base import futures_sign_request
+except ImportError:
+    from pymexc.base import futures_sign_request
+
 logger = logging.getLogger(__name__)
 
 SPOT = "https://api.mexc.com"
-FUTURES = "https://contract.mexc.com"
+FUTURES = "https://api.mexc.com"
 
 
 class MexcAPIError(Exception):
@@ -142,28 +147,6 @@ class _FuturesHTTP(MexcSDK):
             }
         )
 
-    def sign(self, timestamp: str, **kwargs) -> str:
-        """
-        Generates a signature for an API request using HMAC SHA256 encryption.
-
-        :param timestamp: A string representing the timestamp of the request.
-        :type timestamp: str
-        :param kwargs: Arbitrary keyword arguments representing request parameters.
-        :type kwargs: dict
-
-        :return: A hexadecimal string representing the signature of the request.
-        :rtype: str
-        """
-        # Generate signature
-        query_string = "&".join([f"{k}={v}" for k, v in sorted(kwargs.items())])
-        query_string = self.api_key + timestamp + query_string
-        signature = hmac.new(
-            self.api_secret.encode("utf-8"),
-            query_string.encode("utf-8"),
-            hashlib.sha256,
-        ).hexdigest()
-        return signature
-
     async def call(
         self,
         method: Union[Literal["GET"], Literal["POST"], Literal["PUT"], Literal["DELETE"]],
@@ -172,18 +155,12 @@ class _FuturesHTTP(MexcSDK):
         **kwargs,
     ) -> dict:
         """
-        Makes a request to the specified HTTP method and router using the provided arguments.
+        Makes a request to the specified HTTP method and router.
 
-        :param method: A string that represents the HTTP method(GET, POST, PUT, or DELETE) to be used.
-        :type method: str
-        :param router: A string that represents the API endpoint to be called.
-        :type router: str
-        :param *args: Variable length argument list.
-        :type *args: list
-        :param **kwargs: Arbitrary keyword arguments.
-        :type **kwargs: dict
-
-        :return: A dictionary containing the JSON response of the request.
+        POST payloads (passed as either `json=` or `params=`) are serialized
+        to a compact JSON body and signed over api_key + timestamp + body
+        (MEXC integration guide). GET/DELETE keep query params and sign the
+        sorted k=v join. Raises MexcAPIError on HTTP errors.
         """
 
         if not router.startswith("/"):
@@ -205,16 +182,32 @@ class _FuturesHTTP(MexcSDK):
                 elif isinstance(kwarg_variant, list):
                     kwargs[variant] = [v for v in kwarg_variant if v is not None]
 
-        if self.api_key and self.api_secret:
-            # Add signature
-            timestamp = str(int(time.time() * 1000))
-            payload = kwargs.get("json") or kwargs.get("params") or {}
+        payload = kwargs.pop("json", None)
+        if payload is None:
+            payload = kwargs.pop("params", None)
 
+        timestamp = str(int(time.time() * 1000))
+        signature, body, params = futures_sign_request(self.api_key, self.api_secret, timestamp, method, payload)
+
+        if method == "POST":
+            if body:
+                kwargs["data"] = body
+        elif params:
+            kwargs["params"] = params
+
+        if self.api_key and self.api_secret:
             kwargs["headers"] = {
                 "Request-Time": timestamp,
-                "Signature": self.sign(timestamp, **payload),
+                "Signature": signature,
             }
 
         response = await self.session.request(method, f"{self.base_url}{router}", *args, **kwargs)
+
+        if not response.ok:
+            try:
+                error = response.json()
+            except Exception:
+                raise MexcAPIError(f"(HTTP {response.status_code}): {response.text[:200]}")
+            raise MexcAPIError(f"(code={error.get('code')}): {error.get('message') or error.get('msg')}")
 
         return response.json()

--- a/pymexc/base.py
+++ b/pymexc/base.py
@@ -1,9 +1,10 @@
 import hashlib
 import hmac
+import json
 import logging
 import time
 from abc import ABC
-from typing import Literal, Union
+from typing import Literal, Optional, Tuple, Union
 from urllib.parse import urlencode
 
 from curl_cffi import requests
@@ -17,6 +18,38 @@ WEB = "https://futures.mexc.com"
 
 class MexcAPIError(Exception):
     pass
+
+
+def futures_sign_request(
+    api_key: Optional[str],
+    api_secret: Optional[str],
+    timestamp: str,
+    method: str,
+    payload: Union[dict, list, None],
+) -> Tuple[str, Optional[str], Optional[dict]]:
+    """Build the futures API signature per the MEXC integration guide.
+
+    Returns (signature, body, params):
+    - POST: body is the compact JSON string of payload (None -> ""); the
+      signature is computed over api_key + timestamp + body. The caller MUST
+      send body byte-identical as the request data.
+    - GET/DELETE: params passes through; the signature target is the
+      "&"-joined k=v pairs sorted by key.
+    """
+    if method == "POST":
+        body = "" if payload is None else json.dumps(payload, separators=(",", ":"))
+        target = body
+        params = None
+    else:
+        body = None
+        params = payload or {}
+        target = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+    signature = hmac.new(
+        (api_secret or "").encode("utf-8"),
+        f"{api_key or ''}{timestamp}{target}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return signature, body, params
 
 
 class OrderSide:

--- a/pymexc/base.py
+++ b/pymexc/base.py
@@ -12,7 +12,7 @@ from curl_cffi import requests
 logger = logging.getLogger(__name__)
 
 SPOT = "https://api.mexc.com"
-FUTURES = "https://contract.mexc.com"
+FUTURES = "https://api.mexc.com"
 WEB = "https://futures.mexc.com"
 
 
@@ -191,28 +191,6 @@ class _FuturesHTTP(MexcSDK):
 
         self.session.headers.update({"Content-Type": "application/json", "ApiKey": self.api_key})
 
-    def sign(self, timestamp: str, **kwargs) -> str:
-        """
-        Generates a signature for an API request using HMAC SHA256 encryption.
-
-        :param timestamp: A string representing the timestamp of the request.
-        :type timestamp: str
-        :param kwargs: Arbitrary keyword arguments representing request parameters.
-        :type kwargs: dict
-
-        :return: A hexadecimal string representing the signature of the request.
-        :rtype: str
-        """
-        # Generate signature
-        query_string = "&".join([f"{k}={v}" for k, v in sorted(kwargs.items())])
-        query_string = self.api_key + timestamp + query_string
-        signature = hmac.new(
-            self.api_secret.encode("utf-8"),
-            query_string.encode("utf-8"),
-            hashlib.sha256,
-        ).hexdigest()
-        return signature
-
     def call(
         self,
         method: Union[Literal["GET"], Literal["POST"], Literal["PUT"], Literal["DELETE"]],
@@ -221,18 +199,12 @@ class _FuturesHTTP(MexcSDK):
         **kwargs,
     ) -> dict:
         """
-        Makes a request to the specified HTTP method and router using the provided arguments.
+        Makes a request to the specified HTTP method and router.
 
-        :param method: A string that represents the HTTP method(GET, POST, PUT, or DELETE) to be used.
-        :type method: str
-        :param router: A string that represents the API endpoint to be called.
-        :type router: str
-        :param *args: Variable length argument list.
-        :type *args: list
-        :param **kwargs: Arbitrary keyword arguments.
-        :type **kwargs: dict
-
-        :return: A dictionary containing the JSON response of the request.
+        POST payloads (passed as either `json=` or `params=`) are serialized
+        to a compact JSON body and signed over api_key + timestamp + body
+        (MEXC integration guide). GET/DELETE keep query params and sign the
+        sorted k=v join. Raises MexcAPIError on HTTP errors.
         """
 
         if not router.startswith("/"):
@@ -254,17 +226,33 @@ class _FuturesHTTP(MexcSDK):
                 elif isinstance(kwarg_variant, list):
                     kwargs[variant] = [v for v in kwarg_variant if v is not None]
 
-        if self.api_key and self.api_secret:
-            # Add signature
-            timestamp = str(int(time.time() * 1000))
-            payload = kwargs.get("json") or kwargs.get("params") or {}
+        payload = kwargs.pop("json", None)
+        if payload is None:
+            payload = kwargs.pop("params", None)
 
+        timestamp = str(int(time.time() * 1000))
+        signature, body, params = futures_sign_request(self.api_key, self.api_secret, timestamp, method, payload)
+
+        if method == "POST":
+            if body:
+                kwargs["data"] = body
+        elif params:
+            kwargs["params"] = params
+
+        if self.api_key and self.api_secret:
             kwargs["headers"] = {
                 "Request-Time": timestamp,
-                "Signature": self.sign(timestamp, **payload),
+                "Signature": signature,
             }
 
         response = self.session.request(method, f"{self.base_url}{router}", *args, **kwargs)
+
+        if not response.ok:
+            try:
+                error = response.json()
+            except Exception:
+                raise MexcAPIError(f"(HTTP {response.status_code}): {response.text[:200]}")
+            raise MexcAPIError(f"(code={error.get('code')}): {error.get('message') or error.get('msg')}")
 
         return response.json()
 

--- a/pymexc/base.py
+++ b/pymexc/base.py
@@ -229,6 +229,10 @@ class _FuturesHTTP(MexcSDK):
         payload = kwargs.pop("json", None)
         if payload is None:
             payload = kwargs.pop("params", None)
+        if not payload:
+            # all-None optionals strip to {} / []; guide: "if there are no
+            # parameters, use an empty string" - sign "" and send no body
+            payload = None
 
         timestamp = str(int(time.time() * 1000))
         signature, body, params = futures_sign_request(self.api_key, self.api_secret, timestamp, method, payload)

--- a/pymexc/base.py
+++ b/pymexc/base.py
@@ -30,14 +30,16 @@ def futures_sign_request(
     """Build the futures API signature per the MEXC integration guide.
 
     Returns (signature, body, params):
-    - POST: body is the compact JSON string of payload (None -> ""); the
+    - POST: body is the compact JSON string of payload ({} / [] / None -> ""); the
       signature is computed over api_key + timestamp + body. The caller MUST
       send body byte-identical as the request data.
     - GET/DELETE: params passes through; the signature target is the
       "&"-joined k=v pairs sorted by key.
     """
     if method == "POST":
-        body = "" if payload is None else json.dumps(payload, separators=(",", ":"))
+        # {} / [] / None all mean "no parameters"; guide: "if there are no
+        # parameters, use an empty string"
+        body = json.dumps(payload, separators=(",", ":")) if payload else ""
         target = body
         params = None
     else:
@@ -229,10 +231,6 @@ class _FuturesHTTP(MexcSDK):
         payload = kwargs.pop("json", None)
         if payload is None:
             payload = kwargs.pop("params", None)
-        if not payload:
-            # all-None optionals strip to {} / []; guide: "if there are no
-            # parameters, use an empty string" - sign "" and send no body
-            payload = None
 
         timestamp = str(int(time.time() * 1000))
         signature, body, params = futures_sign_request(self.api_key, self.api_secret, timestamp, method, payload)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: live tests against production MEXC API (opt-in via -m integration)
+addopts = -m "not integration"

--- a/tests/test_async_futures_http.py
+++ b/tests/test_async_futures_http.py
@@ -1,0 +1,96 @@
+"""Unit tests for futures signing and transport (async client).
+
+# uv run pytest tests/test_async_futures_http.py -v
+"""
+
+import hashlib
+import hmac
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pymexc._async.base import MexcAPIError
+from pymexc._async.futures import HTTP
+
+API_KEY = "test_key"
+API_SECRET = "test_secret"
+TS = "1700000000000"
+FROZEN_TIME = 1700000000.0
+
+
+def hmac_hex(target: str) -> str:
+    return hmac.new(API_SECRET.encode(), (API_KEY + TS + target).encode(), hashlib.sha256).hexdigest()
+
+
+def make_response(ok=True, status=200, payload=None, text=""):
+    response = MagicMock()
+    response.ok = ok
+    response.status_code = status
+    response.text = text
+    if payload is None:
+        response.json.side_effect = ValueError("not json")
+    else:
+        response.json.return_value = payload
+    return response
+
+
+@pytest.mark.asyncio
+async def test_order_posts_json_body_to_api_mexc_com():
+    client = HTTP(api_key=API_KEY, api_secret=API_SECRET, ignore_ad=True)
+    response = make_response(payload={"success": True, "code": 0, "data": 1})
+    with (
+        patch.object(client.session, "request", new=AsyncMock(return_value=response)) as request_mock,
+        patch("pymexc._async.base.time.time", return_value=FROZEN_TIME),
+    ):
+        result = await client.order(symbol="BTC_USDT", price=30000, vol=1, side=1, type=1, open_type=1, leverage=1)
+    method, url = request_mock.call_args.args
+    kwargs = request_mock.call_args.kwargs
+    assert method == "POST"
+    assert url == "https://api.mexc.com/api/v1/private/order/submit"
+    assert kwargs["data"] == (
+        '{"symbol":"BTC_USDT","price":30000,"vol":1,"side":1,"type":1,'
+        '"openType":1,"leverage":1,"reduceOnly":false}'
+    )
+    assert kwargs["headers"]["Signature"] == hmac_hex(kwargs["data"])
+    assert result == {"success": True, "code": 0, "data": 1}
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_posts_list_body():
+    client = HTTP(api_key=API_KEY, api_secret=API_SECRET, ignore_ad=True)
+    response = make_response(payload={"success": True, "code": 0})
+    with (
+        patch.object(client.session, "request", new=AsyncMock(return_value=response)) as request_mock,
+        patch("pymexc._async.base.time.time", return_value=FROZEN_TIME),
+    ):
+        await client.cancel_order(123456789)
+    kwargs = request_mock.call_args.kwargs
+    assert request_mock.call_args.args[1] == "https://api.mexc.com/api/v1/private/order/cancel"
+    assert kwargs["data"] == "[123456789]"
+    assert kwargs["headers"]["Signature"] == hmac_hex("[123456789]")
+
+
+@pytest.mark.asyncio
+async def test_get_keeps_query_params_and_signs_sorted():
+    client = HTTP(api_key=API_KEY, api_secret=API_SECRET, ignore_ad=True)
+    response = make_response(payload={"success": True, "code": 0, "data": []})
+    with (
+        patch.object(client.session, "request", new=AsyncMock(return_value=response)) as request_mock,
+        patch("pymexc._async.base.time.time", return_value=FROZEN_TIME),
+    ):
+        await client.open_orders(symbol="BTC_USDT")
+    kwargs = request_mock.call_args.kwargs
+    assert kwargs["params"] == {"symbol": "BTC_USDT", "page_num": 1, "page_size": 20}
+    assert kwargs["headers"]["Signature"] == hmac_hex("page_num=1&page_size=20&symbol=BTC_USDT")
+
+
+@pytest.mark.asyncio
+async def test_http_error_raises():
+    client = HTTP(api_key=API_KEY, api_secret=API_SECRET, ignore_ad=True)
+    response = make_response(ok=False, status=403, payload=None, text="<HTML>Access Denied</HTML>")
+    with (
+        patch.object(client.session, "request", new=AsyncMock(return_value=response)),
+        patch("pymexc._async.base.time.time", return_value=FROZEN_TIME),
+    ):
+        with pytest.raises(MexcAPIError, match="HTTP 403"):
+            await client.cancel_order(1)

--- a/tests/test_async_futures_http.py
+++ b/tests/test_async_futures_http.py
@@ -52,6 +52,7 @@ async def test_order_posts_json_body_to_api_mexc_com():
         '"openType":1,"leverage":1,"reduceOnly":false}'
     )
     assert kwargs["headers"]["Signature"] == hmac_hex(kwargs["data"])
+    assert "params" not in kwargs
     assert result == {"success": True, "code": 0, "data": 1}
 
 
@@ -93,4 +94,16 @@ async def test_http_error_raises():
         patch("pymexc._async.base.time.time", return_value=FROZEN_TIME),
     ):
         with pytest.raises(MexcAPIError, match="HTTP 403"):
+            await client.cancel_order(1)
+
+
+@pytest.mark.asyncio
+async def test_http_error_with_json_body_raises():
+    client = HTTP(api_key=API_KEY, api_secret=API_SECRET, ignore_ad=True)
+    response = make_response(ok=False, status=400, payload={"success": False, "code": 602, "message": "Confirming signature failed"})
+    with (
+        patch.object(client.session, "request", new=AsyncMock(return_value=response)),
+        patch("pymexc._async.base.time.time", return_value=FROZEN_TIME),
+    ):
+        with pytest.raises(MexcAPIError, match="code=602"):
             await client.cancel_order(1)

--- a/tests/test_async_spot_http.py
+++ b/tests/test_async_spot_http.py
@@ -12,10 +12,12 @@ from dotenv import dotenv_values
 import pymexc._async.base
 from pymexc._async.spot import HTTP
 
+pytestmark = pytest.mark.integration
+
 env = dotenv_values(".env")
 
-api_key = env["API_KEY"]
-api_secret = env["API_SECRET"]
+api_key = env.get("API_KEY")
+api_secret = env.get("API_SECRET")
 
 PRINT_RESPONSE = True
 

--- a/tests/test_futures_http.py
+++ b/tests/test_futures_http.py
@@ -1,0 +1,60 @@
+"""Unit tests for futures signing and transport (sync client).
+
+# uv run pytest tests/test_futures_http.py -v
+"""
+
+import hashlib
+import hmac
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pymexc.base import MexcAPIError, futures_sign_request
+from pymexc.futures import HTTP
+
+API_KEY = "test_key"
+API_SECRET = "test_secret"
+TS = "1700000000000"
+FROZEN_TIME = 1700000000.0  # int(FROZEN_TIME * 1000) == TS
+
+
+def hmac_hex(target: str) -> str:
+    return hmac.new(API_SECRET.encode(), (API_KEY + TS + target).encode(), hashlib.sha256).hexdigest()
+
+
+class TestFuturesSignRequest:
+    def test_post_dict_payload_signs_compact_json_body(self):
+        payload = {"symbol": "BTC_USDT", "price": 30000, "vol": 1, "side": 1, "type": 1, "openType": 1, "leverage": 1}
+        signature, body, params = futures_sign_request(API_KEY, API_SECRET, TS, "POST", payload)
+        assert body == '{"symbol":"BTC_USDT","price":30000,"vol":1,"side":1,"type":1,"openType":1,"leverage":1}'
+        assert params is None
+        assert signature == "98fa84fee14e3f3654335676706fb6606740bf4f36e06a806c29893e6e8685b2"
+
+    def test_post_list_payload(self):
+        # cancel_order sends a bare list of order ids
+        signature, body, params = futures_sign_request(API_KEY, API_SECRET, TS, "POST", [123456789])
+        assert body == "[123456789]"
+        assert params is None
+        assert signature == "80d8e51224377143717d45628c9fee414051abdaa11c1baa0e377d91bf0901a3"
+
+    def test_post_none_payload_signs_empty_body(self):
+        # change_risk_level posts without payload; integration guide: "if there
+        # are no parameters, use an empty string" (method unused by the bot)
+        signature, body, params = futures_sign_request(API_KEY, API_SECRET, TS, "POST", None)
+        assert body == ""
+        assert params is None
+        assert signature == "88000ed348e8e57dfb4ae8ad93386a021b6f2f41ea839188723b7762d8c01e12"
+
+    def test_get_signs_sorted_kv_join(self):
+        params = {"symbol": "BTC_USDT", "page_num": 1, "page_size": 20}
+        signature, body, out_params = futures_sign_request(API_KEY, API_SECRET, TS, "GET", params)
+        assert body is None
+        assert out_params == params
+        # target: "page_num=1&page_size=20&symbol=BTC_USDT"
+        assert signature == "ead06de1cc6ee1a0311f65949fd89904035a20e7b0e13df74422c8104c48f055"
+
+    def test_get_none_payload_signs_empty_target(self):
+        signature, body, out_params = futures_sign_request(API_KEY, API_SECRET, TS, "GET", None)
+        assert body is None
+        assert out_params == {}
+        assert signature == hmac_hex("")

--- a/tests/test_futures_http.py
+++ b/tests/test_futures_http.py
@@ -148,6 +148,16 @@ class TestFuturesCall:
         with pytest.raises(MexcAPIError, match="HTTP 403"):
             self._call(response, self.client.order, symbol="BTC_USDT", price=1, vol=1, side=1, type=1, open_type=1)
 
+    def test_post_with_all_none_params_sends_no_body_signs_empty(self):
+        # cancel_all() with default symbol=None strips to {} - must behave
+        # like a no-parameter POST: no body, signature over empty string
+        response = make_response(payload={"success": True, "code": 0})
+        _, request_mock = self._call(response, self.client.cancel_all)
+        kwargs = request_mock.call_args.kwargs
+        assert "data" not in kwargs
+        assert "params" not in kwargs
+        assert kwargs["headers"]["Signature"] == hmac_hex("")
+
     def test_unauthenticated_public_get_sends_no_signature(self):
         client = HTTP(ignore_ad=True)
         response = make_response(payload={"success": True, "code": 0, "data": {}})

--- a/tests/test_futures_http.py
+++ b/tests/test_futures_http.py
@@ -58,3 +58,103 @@ class TestFuturesSignRequest:
         assert body is None
         assert out_params == {}
         assert signature == hmac_hex("")
+
+
+def make_response(ok=True, status=200, payload=None, text=""):
+    response = MagicMock()
+    response.ok = ok
+    response.status_code = status
+    response.text = text
+    if payload is None:
+        response.json.side_effect = ValueError("not json")
+    else:
+        response.json.return_value = payload
+    return response
+
+
+class TestFuturesCall:
+    def setup_method(self):
+        self.client = HTTP(api_key=API_KEY, api_secret=API_SECRET, ignore_ad=True)
+
+    def _call(self, response, fn, *args, **kwargs):
+        with (
+            patch.object(self.client.session, "request", return_value=response) as request_mock,
+            patch("pymexc.base.time.time", return_value=FROZEN_TIME),
+        ):
+            result = fn(*args, **kwargs)
+        return result, request_mock
+
+    def test_order_posts_json_body_to_api_mexc_com(self):
+        response = make_response(payload={"success": True, "code": 0, "data": 1})
+        result, request_mock = self._call(
+            response, self.client.order,
+            symbol="BTC_USDT", price=30000, vol=1, side=1, type=1, open_type=1, leverage=1,
+        )
+        method, url = request_mock.call_args.args
+        kwargs = request_mock.call_args.kwargs
+        assert method == "POST"
+        assert url == "https://api.mexc.com/api/v1/private/order/submit"
+        # None-valued optionals stripped; reduce_only=False survives; insertion order kept
+        assert kwargs["data"] == (
+            '{"symbol":"BTC_USDT","price":30000,"vol":1,"side":1,"type":1,'
+            '"openType":1,"leverage":1,"reduceOnly":false}'
+        )
+        assert "params" not in kwargs
+        # byte-identity: signature recomputed over the exact sent body
+        assert kwargs["headers"]["Signature"] == hmac_hex(kwargs["data"])
+        assert kwargs["headers"]["Request-Time"] == TS
+        # ApiKey / Content-Type ride on the session (set in __init__)
+        assert self.client.session.headers["ApiKey"] == API_KEY
+        assert self.client.session.headers["Content-Type"] == "application/json"
+        assert result == {"success": True, "code": 0, "data": 1}
+
+    def test_cancel_order_posts_list_body(self):
+        response = make_response(payload={"success": True, "code": 0})
+        _, request_mock = self._call(response, self.client.cancel_order, 123456789)
+        method, url = request_mock.call_args.args
+        kwargs = request_mock.call_args.kwargs
+        assert method == "POST"
+        assert url == "https://api.mexc.com/api/v1/private/order/cancel"
+        assert kwargs["data"] == "[123456789]"
+        assert kwargs["headers"]["Signature"] == hmac_hex("[123456789]")
+
+    def test_change_leverage_posts_json_body(self):
+        response = make_response(payload={"success": True, "code": 0})
+        _, request_mock = self._call(response, self.client.change_leverage, position_id=1, leverage=20)
+        kwargs = request_mock.call_args.kwargs
+        assert request_mock.call_args.args[1] == "https://api.mexc.com/api/v1/private/position/change_leverage"
+        assert kwargs["data"] == '{"positionId":1,"leverage":20}'
+        assert kwargs["headers"]["Signature"] == hmac_hex(kwargs["data"])
+
+    def test_get_keeps_query_params_and_signs_sorted(self):
+        response = make_response(payload={"success": True, "code": 0, "data": []})
+        _, request_mock = self._call(response, self.client.open_orders, symbol="BTC_USDT")
+        method, url = request_mock.call_args.args
+        kwargs = request_mock.call_args.kwargs
+        assert method == "GET"
+        assert url == "https://api.mexc.com/api/v1/private/order/list/open_orders/BTC_USDT"
+        assert kwargs["params"] == {"symbol": "BTC_USDT", "page_num": 1, "page_size": 20}
+        assert "data" not in kwargs
+        assert kwargs["headers"]["Signature"] == hmac_hex("page_num=1&page_size=20&symbol=BTC_USDT")
+
+    def test_http_error_with_json_body_raises(self):
+        response = make_response(ok=False, status=400, payload={"success": False, "code": 602, "message": "Confirming signature failed"})
+        with pytest.raises(MexcAPIError, match="code=602"):
+            self._call(response, self.client.cancel_order, 1)
+
+    def test_http_error_with_html_body_raises(self):
+        # contract.mexc.com WAF block shape: 403 + Akamai HTML page
+        response = make_response(ok=False, status=403, payload=None, text="<HTML><HEAD>Access Denied</HEAD></HTML>")
+        with pytest.raises(MexcAPIError, match="HTTP 403"):
+            self._call(response, self.client.order, symbol="BTC_USDT", price=1, vol=1, side=1, type=1, open_type=1)
+
+    def test_unauthenticated_public_get_sends_no_signature(self):
+        client = HTTP(ignore_ad=True)
+        response = make_response(payload={"success": True, "code": 0, "data": {}})
+        with (
+            patch.object(client.session, "request", return_value=response) as request_mock,
+            patch("pymexc.base.time.time", return_value=FROZEN_TIME),
+        ):
+            client.ticker(symbol="BTC_USDT")
+        assert request_mock.call_args.kwargs.get("headers") is None
+        assert request_mock.call_args.kwargs["params"] == {"symbol": "BTC_USDT"}

--- a/tests/test_futures_http.py
+++ b/tests/test_futures_http.py
@@ -37,10 +37,11 @@ class TestFuturesSignRequest:
         assert params is None
         assert signature == "80d8e51224377143717d45628c9fee414051abdaa11c1baa0e377d91bf0901a3"
 
-    def test_post_none_payload_signs_empty_body(self):
-        # change_risk_level posts without payload; integration guide: "if there
-        # are no parameters, use an empty string" (method unused by the bot)
-        signature, body, params = futures_sign_request(API_KEY, API_SECRET, TS, "POST", None)
+    @pytest.mark.parametrize("payload", [None, {}, []])
+    def test_post_empty_payload_signs_empty_body(self, payload):
+        # {} / [] / None all mean "no parameters"; integration guide: "if
+        # there are no parameters, use an empty string"
+        signature, body, params = futures_sign_request(API_KEY, API_SECRET, TS, "POST", payload)
         assert body == ""
         assert params is None
         assert signature == "88000ed348e8e57dfb4ae8ad93386a021b6f2f41ea839188723b7762d8c01e12"

--- a/tests/test_futures_http_integration.py
+++ b/tests/test_futures_http_integration.py
@@ -1,0 +1,71 @@
+"""Live validation of futures trading endpoints (basis_fork backlog TASK-19).
+
+Places a far-from-market limit order (~$3 margin, cannot fill) on BTC_USDT,
+verifies it is visible via private GET, then cancels it. Also proves private
+GET endpoints work on api.mexc.com after the base URL flip.
+
+Opt-in only:  uv run pytest tests/test_futures_http_integration.py -m integration -v -s
+Credentials:  .env file (API_KEY / API_SECRET) or environment variables.
+"""
+
+import os
+import time
+
+import pytest
+from dotenv import dotenv_values
+
+from pymexc.futures import HTTP
+
+env = {**dotenv_values(".env"), **os.environ}
+API_KEY = env.get("API_KEY")
+API_SECRET = env.get("API_SECRET")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not API_KEY or not API_SECRET, reason="API_KEY / API_SECRET not configured"),
+]
+
+
+def test_futures_order_lifecycle():
+    client = HTTP(api_key=API_KEY, api_secret=API_SECRET, ignore_ad=True)
+
+    # 1. Public read on api.mexc.com
+    detail = client.detail(symbol="BTC_USDT")
+    assert detail["success"] is True
+    assert detail["data"]["apiAllowed"] is True
+
+    # 2. Private GETs on api.mexc.com (spec decision 2 risk retirement)
+    assets = client.assets()
+    assert assets["success"] is True, f"private GET assets failed on api.mexc.com: {assets}"
+    open_before = client.open_orders(symbol="BTC_USDT")
+    assert open_before["success"] is True, f"private GET open_orders failed on api.mexc.com: {open_before}"
+
+    # 3. Far-from-market limit buy: 50% of market price cannot fill
+    ticker = client.ticker(symbol="BTC_USDT")
+    assert ticker["success"] is True
+    price = round(ticker["data"]["lastPrice"] * 0.5)
+    order = client.order(symbol="BTC_USDT", price=price, vol=1, side=1, type=1, open_type=1, leverage=1)
+    assert order["success"] is True, f"order failed: {order}"
+    # Live-verified /order/submit returned data as the bare order id
+    # (docs/MEXC/futures_api_trading.md, 2026-06-10); the newer official
+    # /order/create documents {"orderId": ..., "ts": ...}. Extract robustly so
+    # a schema change cannot strand a live order.
+    data = order["data"]
+    order_id = data["orderId"] if isinstance(data, dict) else data
+    print(f"\nplaced order {order_id} at {price}")
+
+    try:
+        # 4. Order visible via private GET (TASK-19 AC#2)
+        time.sleep(2)
+        open_after = client.open_orders(symbol="BTC_USDT")
+        assert open_after["success"] is True
+        # str-normalize: docs type orderId as string, live capture returned int
+        assert str(order_id) in [str(o["orderId"]) for o in open_after["data"]], (
+            f"order {order_id} not in open orders: {open_after['data']}"
+        )
+    finally:
+        # 5. Cancel ALWAYS runs - never leave a live order behind
+        cancel = client.cancel_order(order_id)
+        print(f"cancel response: {cancel}")
+        assert cancel["success"] is True, f"CANCEL FAILED - manually cancel order {order_id}: {cancel}"
+        assert cancel["data"][0]["errorCode"] == 0

--- a/tests/test_futures_http_integration.py
+++ b/tests/test_futures_http_integration.py
@@ -51,8 +51,9 @@ def test_futures_order_lifecycle():
     # /order/create documents {"orderId": ..., "ts": ...}. Extract robustly so
     # a schema change cannot strand a live order.
     data = order["data"]
+    print(f"\nraw order response data: {data!r}")
     order_id = data["orderId"] if isinstance(data, dict) else data
-    print(f"\nplaced order {order_id} at {price}")
+    print(f"placed order {order_id} at {price}")
 
     try:
         # 4. Order visible via private GET (TASK-19 AC#2)

--- a/tests/test_spot_http.py
+++ b/tests/test_spot_http.py
@@ -10,10 +10,12 @@ from dotenv import dotenv_values
 import pymexc.base
 from pymexc.spot import HTTP
 
+pytestmark = pytest.mark.integration
+
 env = dotenv_values(".env")
 
-api_key = env["API_KEY"]
-api_secret = env["API_SECRET"]
+api_key = env.get("API_KEY")
+api_secret = env.get("API_SECRET")
 
 http = HTTP(api_key=api_key, api_secret=api_secret)
 


### PR DESCRIPTION
## Summary
- Add `futures_sign_request` as the single source for futures request signing: POST signs `accessKey + timestamp + compact JSON body` (byte-identical to the sent body, `{}`/`[]`/`None` sign the empty string), GET/DELETE keep the sorted `k=v` join
- Route all futures POST payloads as JSON bodies via `call()`-level normalization (sync + async, byte-identical mirrors); flip `FUTURES` base URL to `https://api.mexc.com`; raise `MexcAPIError` on HTTP errors (WAF 403 HTML included)
- Tests: 20 unit tests (signing vectors + mocked transport), opt-in live lifecycle integration test (passed against production 2026-06-10: order placed far-from-market, visible via open_orders, cancelled cleanly); spot live suites now carry the `integration` marker so bare `pytest` cannot fire live orders

## Test Plan
- [x] `uv run pytest tests/test_futures_http.py tests/test_async_futures_http.py -v` - 20 passed
- [x] `uv run pytest tests/test_futures_http_integration.py -m integration -v -s` with creds - live order lifecycle passed (id 819679897441098240)
- [x] `uv run pytest --collect-only -q` - live suites deselected by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)